### PR TITLE
Add colour-coded OBI display

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^1.9.0",
@@ -23,6 +24,7 @@
     "eslint": "^9.28.0",
     "globals": "^16.2.0",
     "husky": "^9.1.7",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "jest": "^29.7.0"
   }
 }

--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -1,0 +1,3 @@
+.obi-bull { color: #28c76f; transition: color 0.2s ease-in-out; }
+.obi-bear { color: #ff5252; transition: color 0.2s ease-in-out; }
+.obi-flat { color: #999;    transition: color 0.2s ease-in-out; }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -12,6 +12,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/grid-lite.js"></script>
   <script src="https://code.highcharts.com/modules/bullet.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@highcharts/grid-lite/css/grid.css"/>
+  <link rel="stylesheet" href="css/dashboard.css"/>
 
   <style>
     /* ─── Global & Sidebar ───────────────────────────────────────────────── */

--- a/public/js/core/dashboard.js
+++ b/public/js/core/dashboard.js
@@ -1,6 +1,7 @@
 
     import { onCtx, onCandle } from './perpDataFeed.js';
     import { BookBiasLine } from '../lib/bookBiasLine.js';
+    import { classifyObi } from "./utils.js";
 
     let obCFD = null;          // ← visible to every function in the module
     let price24hAgo = null;     // fetched once per coin switch
@@ -860,6 +861,12 @@ obiSSE.onmessage = async (e) => {
   /* 3.  Update KPIs – OBI ratio, liquidity */
   const r = d.ratio;
   setHtml('obiRatio', r.toFixed(2));
+  const cls = classifyObi(r);
+  const obiEl = $('obiRatio');
+  if (obiEl) {
+    obiEl.classList.remove('obi-bull','obi-bear','obi-flat');
+    obiEl.classList.add(`obi-${cls}`);
+  }
   setHtml('obiRatioTxt', r >= 1.4 ? 'Bid‑Heavy' : r <= 0.6 ? 'Ask‑Heavy' : 'Balanced');
 
   const totalDepthSnap = d.bidDepth + d.askDepth;   // add this

--- a/public/js/core/utils.js
+++ b/public/js/core/utils.js
@@ -1,0 +1,12 @@
+/**
+ * Classify order-book imbalance ratio relative to 1.0.
+ * @param {number} ratio    bid/ask depth ratio
+ * @param {number} neutral  half-width of neutral band
+ * @returns {'bull'|'bear'|'flat'}
+ */
+export function classifyObi (ratio, neutral = 0.07) {
+  if (typeof ratio !== 'number' || Number.isNaN(ratio)) return 'flat';
+  const delta = ratio - 1;
+  if (Math.abs(delta) <= neutral) return 'flat';
+  return delta > 0 ? 'bull' : 'bear';
+}

--- a/test/dashboard-dom.test.js
+++ b/test/dashboard-dom.test.js
@@ -1,0 +1,13 @@
+/** @jest-environment jsdom */
+import { classifyObi } from '../public/js/core/utils.js';
+
+describe('OBI DOM class', () => {
+  test('flips classes based on ratio', () => {
+    document.body.innerHTML = '<span id="obiRatio" class="obi-flat">--</span>';
+    const el = document.getElementById('obiRatio');
+    const cls = classifyObi(1.2);
+    el.classList.remove('obi-bull','obi-bear','obi-flat');
+    el.classList.add(`obi-${cls}`);
+    expect(el.classList.contains('obi-bull')).toBe(true);
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,15 @@
+import { classifyObi } from '../public/js/core/utils.js';
+
+describe('classifyObi', () => {
+  test('returns bull above neutral', () => {
+    expect(classifyObi(1.2, 0.07)).toBe('bull');
+  });
+
+  test('returns bear below neutral', () => {
+    expect(classifyObi(0.8, 0.07)).toBe('bear');
+  });
+
+  test('returns flat inside band', () => {
+    expect(classifyObi(1.03, 0.07)).toBe('flat');
+  });
+});


### PR DESCRIPTION
## Summary
- create `utils.js` with `classifyObi` helper
- apply helper in dashboard OBI SSE handler
- style OBI number with new `obi-bull`, `obi-bear` and `obi-flat` classes
- include `dashboard.css` and link it from dashboard page
- add Jest tests for helper and DOM behaviour
- add Jest to dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ca81863088329bee6df3d39413716