### PR TITLE
Implement dynamic rolling bias colors

### DIFF
--- a/public/css/dashboard.css
+++ b/public/css/dashboard.css
@@ -1,3 +1,3 @@
 .obi-bull { color: #28c76f; transition: color 0.2s ease-in-out; }
 .obi-bear { color: #ff5252; transition: color 0.2s ease-in-out; }
-.obi-flat { color: #999;    transition: color 0.2s ease-in-out; }
+.obi-flat { color: #888;    transition: color 0.2s ease-in-out; }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -127,7 +127,7 @@
 
   .obi-bull { color:#28c76f; transition:color .15s ease-in; }
   .obi-bear { color:#ff5252; transition:color .15s ease-in; }
-  .obi-flat { color:#2b4456; transition:color .15s ease-in; }  /* your default */
+  .obi-flat { color:#888; transition:color .15s ease-in; }
 
   /* tiny 8 px circle */
 .status-dot {

--- a/public/js/core/dashboard.js
+++ b/public/js/core/dashboard.js
@@ -1,7 +1,7 @@
 
     import { onCtx, onCandle } from './perpDataFeed.js';
     import { BookBiasLine } from '../lib/bookBiasLine.js';
-    import { classifyObi } from "./utils.js";
+    import { classifyObi, classifyBias } from "./utils.js";
     import { formatCompact } from '../lib/formatCompact.js';
 import { stateOiFunding, stateStrength, paintDot } from '../lib/statusDots.js';
 import { RollingBias } from '../lib/rollingBias.js';
@@ -243,6 +243,17 @@ function setTxt(id, txt) {
 
       elNum.classList.add(cls);
       elTxt.classList.add(cls);
+    }
+
+    function colourBias(val){
+      const num = document.getElementById('biasRoll');
+      const txt = document.getElementById('biasRollTxt');
+      if (!num || !txt) return;
+      num.classList.remove('obi-bull','obi-bear','obi-flat');
+      txt.classList.remove('obi-bull','obi-bear','obi-flat');
+      const cls = 'obi-' + classifyBias(val);
+      num.classList.add(cls);
+      txt.classList.add(cls);
     }
     /* helper – call whenever you need the current yard-stick           */
     function bigPrintThreshold () {
@@ -1479,6 +1490,7 @@ flowSSE.onmessage = (e) => {
   setHtml('biasRoll',     biasVal.toFixed(2));
   setHtml('biasRollTxt',  biasVal > 0 ? 'Bullish'
                         : biasVal < 0 ? 'Bearish' : 'Flat');
+  colourBias(biasVal);
   
 
   /* ─── 11.  Bull / Bear composite meters  ───────────────────── */

--- a/public/js/core/utils.js
+++ b/public/js/core/utils.js
@@ -10,3 +10,13 @@ export function classifyObi (ratio, neutral = 0.07) {
   if (Math.abs(delta) <= neutral) return 'flat';
   return delta > 0 ? 'bull' : 'bear';
 }
+
+/**
+ * Classify rolling bias value by sign.
+ * @param {number} val
+ * @returns {'bull'|'bear'|'flat'}
+ */
+export function classifyBias (val) {
+  if (typeof val !== 'number' || Number.isNaN(val) || val === 0) return 'flat';
+  return val > 0 ? 'bull' : 'bear';
+}

--- a/test/dashboard-dom.test.js
+++ b/test/dashboard-dom.test.js
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { classifyObi } from '../public/js/core/utils.js';
+import { classifyObi, classifyBias } from '../public/js/core/utils.js';
 
 describe('OBI DOM class', () => {
   test('flips classes based on ratio', () => {
@@ -9,5 +9,21 @@ describe('OBI DOM class', () => {
     el.classList.remove('obi-bull','obi-bear','obi-flat');
     el.classList.add(`obi-${cls}`);
     expect(el.classList.contains('obi-bull')).toBe(true);
+  });
+});
+
+describe('Rolling bias DOM class', () => {
+  test('applies bull/bear/flat classes', () => {
+    document.body.innerHTML = '<span id="biasRoll" class="obi-flat">--</span>' +
+                             '<span id="biasRollTxt" class="obi-flat"></span>';
+    const cls = classifyBias(0.4);
+    const num = document.getElementById('biasRoll');
+    const txt = document.getElementById('biasRollTxt');
+    num.classList.remove('obi-bull','obi-bear','obi-flat');
+    txt.classList.remove('obi-bull','obi-bear','obi-flat');
+    num.classList.add(`obi-${cls}`);
+    txt.classList.add(`obi-${cls}`);
+    expect(num.classList.contains('obi-bull')).toBe(true);
+    expect(txt.classList.contains('obi-bull')).toBe(true);
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,4 @@
-import { classifyObi } from '../public/js/core/utils.js';
+import { classifyObi, classifyBias } from '../public/js/core/utils.js';
 
 describe('classifyObi', () => {
   test('returns bull above neutral', () => {
@@ -11,5 +11,19 @@ describe('classifyObi', () => {
 
   test('returns flat inside band', () => {
     expect(classifyObi(1.03, 0.07)).toBe('flat');
+  });
+});
+
+describe('classifyBias', () => {
+  test('returns bull for positive bias', () => {
+    expect(classifyBias(0.5)).toBe('bull');
+  });
+
+  test('returns bear for negative bias', () => {
+    expect(classifyBias(-0.2)).toBe('bear');
+  });
+
+  test('returns flat for zero', () => {
+    expect(classifyBias(0)).toBe('flat');
   });
 });


### PR DESCRIPTION
## Summary
- color-code rolling bias big number using bull/bear/flat classes
- expose `classifyBias` helper
- test bias classification and DOM behavior
- adjust CSS to use proper gray color

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d082ec75c8329bb04d163f8fdf344