### PR TITLE
Add Highcharts navigator to CFD chart

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>OBI / Flow — Live Dashboard</title>
 
-  <!-- Highcharts core + Grid-Lite + Accessibility -->
-  <script src="https://code.highcharts.com/highcharts.js"></script>
+  <!-- Highcharts Stock + Grid-Lite + Accessibility -->
+  <script src="https://code.highcharts.com/stock/highstock.js"></script>
   <script src="https://code.highcharts.com/highcharts-more.js"></script>
   <script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
   <script src="https://code.highcharts.com/modules/accessibility.js"></script>

--- a/public/js/core/dashboard.js
+++ b/public/js/core/dashboard.js
@@ -774,8 +774,8 @@ function regimeDetails(value) {
 
 function initCFDChart () {
   if (obCFD) return;             // already initialised
-    obCFD = Highcharts.chart('obCfd', {
-      chart : { type:'area', height:320, spacing:[10,10,25,10], zoomType:'x' },
+  obCFD = Highcharts.stockChart('obCfd', {
+    chart : { height:320, spacing:[10,10,25,10] },
       title : { text:'Order-Book Imbalance CFD', style:{ fontSize:'15px' } },
       xAxis : { type:'datetime', labels : { format : '{value:%H:%M:%S}' } },
       yAxis : [{


### PR DESCRIPTION
## Summary
- load Highcharts Stock scripts
- initialise CFD chart with Highcharts.stockChart and navigator

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d0ec2d95c8329974e3fa5a29288c2