### PR TITLE
Add rolling bias timer to dashboard

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -252,6 +252,7 @@
       <span class="obi-kpi-label">Rolling Bias</span>
       <span class="obi-kpi-value"  id="biasRoll">--</span>
       <span class="obi-kpi-detail" id="biasRollTxt"></span>
+      <span class="obi-kpi-detail" id="biasRollTimer">00:00</span>
     </div>
 
   </div> <!-- /.obi-headline-bar -->

--- a/public/js/lib/biasTimer.js
+++ b/public/js/lib/biasTimer.js
@@ -1,0 +1,65 @@
+export class BiasTimer {
+  #displayId;
+  #sign = 0;
+  #start = Date.now();
+  #interval = null;
+
+  constructor(displayId = 'biasRollTimer') {
+    this.#displayId = displayId;
+    this.#load();
+  }
+
+  #load() {
+    const saved = localStorage.getItem('biasTimer');
+    if (!saved) return;
+    try {
+      const obj = JSON.parse(saved);
+      if (typeof obj.sign === 'number') this.#sign = obj.sign;
+      if (typeof obj.start === 'number') this.#start = obj.start;
+    } catch { /* ignore */ }
+  }
+
+  #save() {
+    localStorage.setItem('biasTimer', JSON.stringify({
+      sign: this.#sign,
+      start: this.#start
+    }));
+  }
+
+  #formatSecs(secs) {
+    const m = Math.floor(secs / 60).toString().padStart(2, '0');
+    const s = (secs % 60).toString().padStart(2, '0');
+    return `${m}:${s}`;
+  }
+
+  #tick = () => {
+    const el = document.getElementById(this.#displayId);
+    if (!el) return;
+    const secs = Math.floor((Date.now() - this.#start) / 1000);
+    el.textContent = this.#formatSecs(secs);
+  };
+
+  start() {
+    this.#tick();
+    clearInterval(this.#interval);
+    this.#interval = setInterval(this.#tick, 1000);
+  }
+
+  stop() {
+    clearInterval(this.#interval);
+    this.#interval = null;
+  }
+
+  update(biasVal) {
+    const sign = biasVal > 0 ? 1 : biasVal < 0 ? -1 : 0;
+    if (sign !== this.#sign) {
+      this.#sign = sign;
+      this.#start = Date.now();
+      this.#save();
+    }
+  }
+
+  elapsedSeconds() {
+    return Math.floor((Date.now() - this.#start) / 1000);
+  }
+}

--- a/test/biasTimer.test.js
+++ b/test/biasTimer.test.js
@@ -1,0 +1,33 @@
+/** @jest-environment jsdom */
+import { BiasTimer } from '../public/js/lib/biasTimer.js';
+
+describe('BiasTimer', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  test('resumes from saved start time', () => {
+    localStorage.setItem('biasTimer', JSON.stringify({ sign: 1, start: 5000 }));
+    document.body.innerHTML = '<span id="timer"></span>';
+    jest.setSystemTime(8000);
+    const timer = new BiasTimer('timer');
+    timer.start();
+    expect(document.getElementById('timer').textContent).toBe('00:03');
+    jest.advanceTimersByTime(2000);
+    expect(document.getElementById('timer').textContent).toBe('00:05');
+  });
+
+  test('resets when sign changes', () => {
+    localStorage.setItem('biasTimer', JSON.stringify({ sign: 1, start: 5000 }));
+    document.body.innerHTML = '<span id="timer"></span>';
+    jest.setSystemTime(10000);
+    const timer = new BiasTimer('timer');
+    timer.start();
+    expect(timer.elapsedSeconds()).toBe(5);
+    timer.update(-0.5);
+    expect(timer.elapsedSeconds()).toBe(0);
+    jest.advanceTimersByTime(1000);
+    expect(document.getElementById('timer').textContent).toBe('00:01');
+  });
+});


### PR DESCRIPTION
## Summary
- add `BiasTimer` helper to manage timer state
- show timer beside rolling bias metric
- update dashboard logic to maintain timer
- test new `BiasTimer` behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d14b3eab88329ad36791fee8da0f0