### PR TITLE
Implement smart-money probing radar

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -180,6 +180,17 @@
 .bullish-color{ color:#18b76e; font-weight:600; }
 .bearish-color{ color:#ff4d4d; font-weight:600; }
 
+    /* --- Bubble Radar layout --- */
+    #signalRadar {
+      flex: 1 0 100%;
+      margin-bottom: 6px;
+    }
+    .state-block {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
   </style>
 </head>
 <body>
@@ -306,8 +317,9 @@
   <span id="card-upd" class="last-upd"
         style="font-size:11px;color:#555"></span>
 
-  <!-- ─── Bull / Bear spectrum meters ────────────────────────────── -->
-  <div class="obi-spectrum-row">
+  <!-- ─── Bull / Bear spectrum meters + Signal Radar ─────────────── -->
+  <div class="obi-spectrum-row state-block">
+    <div id="signalRadar"></div>
     <div class="spectrum-meter">
       <div id="bullMeter"></div>
       <div id="bullRegime" class="spectrum-regime-overlay"></div>

--- a/public/js/core/signalRadar.js
+++ b/public/js/core/signalRadar.js
@@ -1,0 +1,78 @@
+export class SignalRadar {
+  constructor(containerId) {
+    this.points = [];
+    this.chart = Highcharts.chart(containerId, {
+      chart: { type: 'bubble', height: 190, backgroundColor: 'transparent' },
+      title: { text: '<b>Flow-Signal Radar</b>', align: 'center', style:{fontSize:'16px'} },
+      xAxis: { min: -1.05, max: 1.05, tickInterval: 0.5, gridLineWidth: 0 },
+      yAxis: { min: 0, max: 180, reversed: true,
+        labels: { formatter() { return this.value + ' s'; } } },
+      tooltip: {
+        useHTML: true,
+        pointFormatter() {
+          const m = this.meta || {};
+          const d = typeof m['\u0394Depth'] === 'number' ?
+            `Bids +${m['\u0394Depth'].toFixed(0)}$` : '';
+          const p = typeof m.PxTrend === 'number' ?
+            ` price ${m.PxTrend.toFixed(2)}%` : '';
+          return `<b>${this.tag}</b><br>` +
+            Highcharts.dateFormat('%H:%M:%S', this.xRaw) + '<br>' +
+            `Strength ${Highcharts.numberFormat(this.strength,2)}<br>` + d + p;
+        }
+      },
+      series: [{ name: 'Signals', data: [] }],
+      plotOptions: { bubble: { minSize: '3%', maxSize: '12%', opacity: 0.85 } },
+      credits: { enabled: false },
+      exporting: { enabled: false }
+    });
+    this.timer = setInterval(()=>this.tick(), 1000);
+  }
+
+  addProbe({ stateScore=0, strength=0.3, ts=Date.now(), meta={} }) {
+    const point = {
+      x: stateScore,
+      y: 0,
+      z: Math.sqrt(strength) * 35,
+      color: 'rgba(50,210,110,0.5)',
+      marker: { symbol: 'triangle' },
+      tag: 'Probe',
+      xRaw: ts,
+      strength,
+      meta
+    };
+    this.chart.series[0].addPoint(point, true, false);
+    this.points.push({ born: ts, strength, point });
+    if (this.points.length > 400) {
+      this.points.sort((a,b)=>a.strength-b.strength);
+      const excess = this.points.splice(0, this.points.length-400);
+      excess.forEach(p=>{
+        const idx = this.chart.series[0].data.indexOf(p.point);
+        if (idx>-1) this.chart.series[0].data[idx].remove(false);
+      });
+      this.chart.redraw(false);
+    }
+  }
+
+  tick() {
+    const now = Date.now();
+    const series = this.chart.series[0];
+    let dirty = false;
+    for (let i = this.points.length-1; i >= 0; i--) {
+      const p = this.points[i];
+      const age = (now - p.born)/1000;
+      if (age > 180) {
+        const idx = series.data.indexOf(p.point);
+        if (idx>-1) series.data[idx].remove(false);
+        this.points.splice(i,1);
+        dirty = true;
+      } else {
+        const idx = series.data.indexOf(p.point);
+        if (idx>-1) series.data[idx].update({ y: age }, false);
+        dirty = true;
+      }
+    }
+    if (dirty) this.chart.redraw(false);
+  }
+
+  destroy() { clearInterval(this.timer); }
+}


### PR DESCRIPTION
## Summary
- add bubble radar Highcharts component
- insert signal radar container and styles in dashboard
- track order book and price to trigger probe signals
- expose stateScore for radar positioning

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d1c438eb083299fde34c28a6d9b50