### PR TITLE
Implement early-warn exhaustion radar bubbles

### DIFF
--- a/public/js/core/dashboard.js
+++ b/public/js/core/dashboard.js
@@ -424,7 +424,8 @@ if (!(up && up.length === base.length && lo && lo.length === base.length)) {
         lastHeavy   = 0,
         lastExtreme = {side:0,ts:0},
         lastSpread  = null,
-        lastLaR     = 0.3; // ◀── TODO: replace with your realized-vol calculation
+        lastLaR     = 0.3, // ◀── TODO: replace with your realized-vol calculation
+        lastWarnGauge = 0;
 
      if (!Number.isFinite(lastLaR)) lastLaR = 0;        
 
@@ -1518,6 +1519,26 @@ flowSSE.onmessage = (e) => {
   updW(w); setGaugeStatus('statusWarn',     w);
   updS(s); setGaugeStatus('statusSqueeze',  s);
   updF(f); setGaugeStatus('statusFake',     f);
+
+  if (w >= 0.10 && lastWarnGauge < 0.10) {
+    radar.addEarlyWarn({
+      stateScore: window.stateScore || 0,
+      strength: w,
+      ts: now,
+      side: 'ask',
+      meta: { type: 'Ask exhaustion', value: w }
+    });
+  }
+  if (w <= -0.10 && lastWarnGauge > -0.10) {
+    radar.addEarlyWarn({
+      stateScore: window.stateScore || 0,
+      strength: w,
+      ts: now,
+      side: 'bid',
+      meta: { type: 'Bid exhaustion', value: w }
+    });
+  }
+  lastWarnGauge = w;
 
   
 


### PR DESCRIPTION
## Summary
- expose new `SignalRadar.addEarlyWarn` method to show ask/bid exhaustion bubbles
- track last Early‑Warn gauge score and add radar bubbles when crossing ±0.10

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d206febac83298e2ffc6d579f12ee