### PR TITLE
Update signal radar bubble logic

### DIFF
--- a/test/signalRadar.test.js
+++ b/test/signalRadar.test.js
@@ -52,4 +52,16 @@ describe('SignalRadar', () => {
     expect(point.removed).toBe(true);
     expect(radar.chart.series[0].data).not.toContain(point);
   });
+
+  test('bubble can start at custom recency', () => {
+    const radar = new SignalRadar('rad');
+    radar.addProbe({ stateScore: 0, strength: 0.4, ts: Date.now(), startY: 10 });
+    const point = radar.chart.series[0].data[0];
+    expect(point.y).toBe(10);
+
+    jest.advanceTimersByTime(5000);
+    jest.setSystemTime(5000);
+
+    expect(point.y).toBeCloseTo(15, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- extend SignalRadar bubble chart with labelled regime bands
- allow bubbles to start at arbitrary recency and always use circle markers
- highlight bubbles by colour group when clicked
- add corresponding unit test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d2e0f92a08329813ab9ce7a8ec976