### PR TITLE
Add signal config for radar bubbles

### DIFF
--- a/public/js/core/signalConfig.js
+++ b/public/js/core/signalConfig.js
@@ -1,0 +1,29 @@
+export default {
+  probe: {
+    id: 'probe',
+    label: 'Probe',
+    zone: 0,
+    color: { bull: '#17c964', bear: '#ff4d4d' },
+    shape: 'circle',
+    normalization: { scale: 35 },
+    tooltip: 'Depth probe event'
+  },
+  askExhaustion: {
+    id: 'askExhaustion',
+    label: 'Ask exhaustion',
+    zone: 0.5,
+    color: '#17c964',
+    shape: 'circle',
+    normalization: { scale: 120 },
+    tooltip: 'Ask-side exhaustion'
+  },
+  bidExhaustion: {
+    id: 'bidExhaustion',
+    label: 'Bid exhaustion',
+    zone: -0.5,
+    color: '#ff4d4d',
+    shape: 'circle',
+    normalization: { scale: 120 },
+    tooltip: 'Bid-side exhaustion'
+  }
+};


### PR DESCRIPTION
## Summary
- add `signalConfig.js` as central registry for signal metadata
- load config in `SignalRadar` and use it when plotting probes and early warnings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d353f72348329bb5ee71b58cd7c61