### PR TITLE
Add Ignition Spark signal

### DIFF
--- a/public/js/core/dashboard.js
+++ b/public/js/core/dashboard.js
@@ -425,7 +425,10 @@ if (!(up && up.length === base.length && lo && lo.length === base.length)) {
         lastExtreme = {side:0,ts:0},
         lastSpread  = null,
         lastLaR     = 0.3, // ◀── TODO: replace with your realized-vol calculation
-        lastWarnGauge = 0;
+        lastWarnGauge = 0,
+        lastMomGauge = 0,
+        lastSparkUp = 0,
+        lastSparkDown = 0;
 
      if (!Number.isFinite(lastLaR)) lastLaR = 0;        
 
@@ -1490,6 +1493,27 @@ flowSSE.onmessage = (e) => {
     : 0;
   updMom(momVal);
   setGaugeStatus('statusMom', momVal);
+  if (momVal > 0.30 && lastMomGauge <= 0.30 && now - lastSparkUp > 5000) {
+    radar.addIgnitionSpark({
+      stateScore: window.stateScore || 0,
+      strength: momVal,
+      ts: now,
+      side: 'up',
+      meta: { value: momVal }
+    });
+    lastSparkUp = now;
+  }
+  if (momVal < -0.30 && lastMomGauge >= -0.30 && now - lastSparkDown > 5000) {
+    radar.addIgnitionSpark({
+      stateScore: window.stateScore || 0,
+      strength: momVal,
+      ts: now,
+      side: 'down',
+      meta: { value: momVal }
+    });
+    lastSparkDown = now;
+  }
+  lastMomGauge = momVal;
 
   /* ─── 7.  Donut counters & ticker messages  ────────────────── */
   if (isAbs) absCount[t.side]++;

--- a/public/js/core/signalConfig.js
+++ b/public/js/core/signalConfig.js
@@ -25,5 +25,29 @@ export default {
     shape: 'circle',
     normalization: { scale: 120 },
     tooltip: 'Bid-side exhaustion'
+  },
+  ignition_spark_up: {
+    id: 'ignition_spark_up',
+    label: 'Ignition Spark \u2191',
+    zone: 0.5,
+    color: '#f4d142',
+    shape: 'triangle',
+    normalize: { max: 1 },
+    tooltip: 'Momentum-Ignition > +0.30 within seconds',
+    meta: { side: 'bull', category: 'breakout' },
+    implementationTip: 'momGauge > 0.30 && \u0394t \u2264 5 s',
+    valueEffort: { value: 5, effort: 3 }
+  },
+  ignition_spark_down: {
+    id: 'ignition_spark_down',
+    label: 'Ignition Spark \u2193',
+    zone: -0.5,
+    color: '#f4d142',
+    shape: 'triangle',
+    normalize: { max: 1 },
+    tooltip: 'Momentum-Ignition < \u20130.30 inside seconds',
+    meta: { side: 'bear', category: 'breakout' },
+    implementationTip: 'momGauge < -0.30 && \u0394t \u2264 5 s',
+    valueEffort: { value: 5, effort: 3 }
   }
 };

--- a/test/ignitionSpark.test.js
+++ b/test/ignitionSpark.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+import { SignalRadar } from '../public/js/core/signalRadar.js';
+
+function makeHighchartsStub() {
+  return {
+    chart: jest.fn(() => ({
+      series: [{
+        data: [],
+        addPoint(point) {
+          this.data.push(Object.assign(point, {
+            update(changes) { Object.assign(this, changes); },
+            remove() { this.removed = true; }
+          }));
+        }
+      }],
+      redraw: jest.fn()
+    }))
+  };
+}
+
+describe('Ignition Spark signal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    global.Highcharts = makeHighchartsStub();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('uses config properties', () => {
+    const radar = new SignalRadar('rad');
+    radar.addIgnitionSpark({ side: 'up', strength: 0.8, ts: Date.now() });
+    const cfg = radar.config.ignition_spark_up;
+    const p = radar.chart.series[0].data[0];
+    expect(p.x).toBe(cfg.zone);
+    expect(p.color).toBe(cfg.color);
+    expect(p.marker.symbol).toBe(cfg.shape);
+    expect(p.tag).toBe(cfg.label);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `signalConfig` with ignition spark config entries
- implement `addIgnitionSpark` in SignalRadar
- trigger ignition spark bubbles on momentum gauge spikes
- test ignition spark signal

## Testing
- `npx jest` *(fails: request to https://registry.npmjs.org/jest failed)*

------
https://chatgpt.com/codex/tasks/task_e_683d402f78b083298a86ff090f1e8986