### PR TITLE
Add early warn exhaustion bubbles

### DIFF
--- a/public/js/core/dashboard.js
+++ b/public/js/core/dashboard.js
@@ -1544,18 +1544,16 @@ flowSSE.onmessage = (e) => {
   updS(s); setGaugeStatus('statusSqueeze',  s);
   updF(f); setGaugeStatus('statusFake',     f);
 
-  if (w >= 0.10 && lastWarnGauge < 0.10) {
+  if (w > 0 && lastWarnGauge <= 0) {
     radar.addEarlyWarn({
-      stateScore: window.stateScore || 0,
       strength: w,
       ts: now,
       side: 'ask',
       meta: { type: 'Ask exhaustion', value: w }
     });
   }
-  if (w <= -0.10 && lastWarnGauge > -0.10) {
+  if (w < 0 && lastWarnGauge >= 0) {
     radar.addEarlyWarn({
-      stateScore: window.stateScore || 0,
       strength: w,
       ts: now,
       side: 'bid',

--- a/public/js/core/signalConfig.js
+++ b/public/js/core/signalConfig.js
@@ -49,5 +49,25 @@ export default {
     meta: { side: 'bear', category: 'breakout' },
     implementationTip: 'momGauge < -0.30 && \u0394t \u2264 5 s',
     valueEffort: { value: 5, effort: 3 }
+  },
+  early_warn_ask: {
+    id: 'early_warn_ask',
+    label: 'Ask Exhaustion',
+    zone: 0.70,
+    color: '#3ad17d',
+    shape: 'circle',
+    normalize: { max: 1 },
+    tooltip: 'Early-Warn flips positive: bids absorb, asks vanish',
+    meta: { side: 'bull', category: 'reversal' }
+  },
+  early_warn_bid: {
+    id: 'early_warn_bid',
+    label: 'Bid Exhaustion',
+    zone: -0.70,
+    color: '#ff6e6e',
+    shape: 'circle',
+    normalize: { max: 1 },
+    tooltip: 'Early-Warn flips negative: asks absorb, bids vanish',
+    meta: { side: 'bear', category: 'reversal' }
   }
 };


### PR DESCRIPTION
## Summary
- configure early warning signals for ask/bid in `signalConfig`
- render early warning bubbles using new config in `signalRadar`
- trigger early warn when gauge crosses 0 in `dashboard`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d44769a5083298a7fd6db2ddcd6c1