### PR TITLE
Add Sell-the-Rally radar signal

### DIFF
--- a/public/js/core/dashboard.js
+++ b/public/js/core/dashboard.js
@@ -429,9 +429,11 @@ if (!(up && up.length === base.length && lo && lo.length === base.length)) {
         lastMomGauge = 0,
         lastSparkUp = 0,
         lastSparkDown = 0,
-        lastBuyDip = 0;
+        lastBuyDip = 0,
+        lastSellRally = 0;
 
     const BUY_DIP_DEDUP_MS = 30_000;
+    const SELL_RALLY_DEDUP_MS = 30_000;
 
      if (!Number.isFinite(lastLaR)) lastLaR = 0;        
 
@@ -1578,6 +1580,15 @@ flowSSE.onmessage = (e) => {
       side: 'bid',
       meta: { type: 'Bid exhaustion', value: w }
     });
+    const trend = calcShortTrend(priceProbeBuf);
+    if (trend > 0.001 && now - lastSellRally > SELL_RALLY_DEDUP_MS) {
+      radar.addSellTheRally({
+        strength: w,
+        ts: now,
+        meta: { PxTrend: trend * 100 }
+      });
+      lastSellRally = now;
+    }
   }
   lastWarnGauge = w;
 

--- a/public/js/core/signalConfig.js
+++ b/public/js/core/signalConfig.js
@@ -95,5 +95,18 @@ export default {
     meta: { side: 'bull', category: 'continuation' },
     implementationTip: 'trigger once earlyWarn flips >0 after dip',
     valueEffort: { value: 4, effort: 3 }
+  },
+
+  sell_the_rally: {
+    id: 'sell_the_rally',
+    label: 'Sell-the-Rally Footprint',
+    zone: -0.40,
+    color: '#c0392b',
+    shape: 'circle',
+    normalize: { max: 1 },
+    tooltip: 'Early-Warn < 0 after up-leg; ask absorption resumes',
+    meta: { side: 'bear', category: 'continuation' },
+    implementationTip: 'earlyWarnGauge < 0 post pop',
+    valueEffort: { value: 4, effort: 3 }
   }
 };

--- a/public/js/core/signalRadar.js
+++ b/public/js/core/signalRadar.js
@@ -254,6 +254,47 @@ export class SignalRadar {
     }
   }
 
+  addSellTheRally({
+    strength = 0.1,
+    ts = Date.now(),
+    meta = {},
+    startY = 0
+  }) {
+    const cfg = this.config.sell_the_rally;
+    if (!cfg) {
+      console.warn('Missing config for sell_the_rally');
+      return;
+    }
+    const val = -1;
+    const max = cfg.normalize?.max ?? 1;
+    const scale = 40;
+    const point = {
+      x: cfg.zone ?? -0.4,
+      y: startY,
+      z: Math.min(Math.abs(strength) / max, 1) * scale,
+      colorValue: val,
+      color: cfg.color || '#c0392b',
+      marker: { symbol: cfg.shape || 'circle' },
+      tag: cfg.label || 'Sell-the-Rally Footprint',
+      xRaw: ts,
+      strength: Math.abs(strength),
+      meta: { ...cfg.meta, value: strength, ...meta }
+    };
+    if (point.strength <= 0) return;
+    this.chart.series[0].addPoint(point, true, false, { duration: 300 });
+    const hcPoint = this.chart.series[0].data[this.chart.series[0].data.length - 1];
+    this.points.push({ born: ts, startY, strength: point.strength, point: hcPoint });
+    if (this.points.length > 400) {
+      this.points.sort((a, b) => a.strength - b.strength);
+      const excess = this.points.splice(0, this.points.length - 400);
+      excess.forEach(p => {
+        const idx = this.chart.series[0].data.indexOf(p.point);
+        if (idx > -1) this.chart.series[0].data[idx].remove(false);
+      });
+      this.chart.redraw(false);
+    }
+  }
+
   addOrUpdateProbe({ id, stateScore = 0, strength = 0.1, ts = Date.now(), meta = {}, startY = 0 }) {
     const cfg = this.config[id];
     if (!cfg) {


### PR DESCRIPTION
## Summary
- add `sell_the_rally` configuration
- allow radar to render Sell‑the‑Rally bubbles
- trigger signal when Early‑Warn flips negative after rally

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d9a591ae8832995b8a9445fdc5795