### PR TITLE
Fix Highcharts module import

### DIFF
--- a/public/js/core/dashboard.js
+++ b/public/js/core/dashboard.js
@@ -1,10 +1,5 @@
 
-import Highcharts from 'highcharts';
-import HighchartsStock from 'highcharts/modules/stock';
-import HighchartsSolidGauge from 'highcharts/modules/solid-gauge';
-
-HighchartsStock(Highcharts);
-HighchartsSolidGauge(Highcharts);
+const Highcharts = window.Highcharts;
 
 import { connect, setCoin, onCtx, onCandle } from './perpDataFeed.js';
 import { BookBiasLine } from '../lib/bookBiasLine.js';


### PR DESCRIPTION
## Summary
- remove ES module imports for Highcharts in `dashboard.js`
- use the global Highcharts loaded by the HTML page

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842daca7d84832993fe3a866f13962f