### PR TITLE
Add standalone tape flow module

### DIFF
--- a/absorb/README.md
+++ b/absorb/README.md
@@ -1,0 +1,23 @@
+# Absorption and Rolling Bias Module
+
+This folder contains standalone utilities for detecting tape flow events
+(absorptions and exhaustions) and computing rolling bias values.
+The code was extracted from the main server logic to allow easier
+analysis and independent testing.
+
+`rollingBias.js` implements a small class that maintains a rolling window
+of absorption/exhaustion events and returns the current bias value.
+
+`tapeFlow.js` exposes:
+
+- `depthDiff(pre, post)` – calculate how much order book depth was eaten on
+  each side between two snapshots.
+- `classifyTrade(trade, preBook, postBook)` – given a trade and book
+  snapshots before and after it, returns a structured event describing the
+  absorption/exhaustion.
+- `TapeFlowAnalyzer` – small helper class that uses `classifyTrade` and
+  updates a `RollingBias` instance. It prints the resulting event to the
+  console and allows reading the current bias via `getBias()`.
+
+These utilities do not depend on the rest of the repository and can be
+imported in isolation for further experimentation or integration.

--- a/absorb/demo.js
+++ b/absorb/demo.js
@@ -1,0 +1,19 @@
+import { TapeFlowAnalyzer } from './tapeFlow.js';
+
+// Simple demo using fabricated data
+const analyzer = new TapeFlowAnalyzer(5);
+
+const pre = {
+  bids: [[100, 2]],
+  asks: [[101, 1]]
+};
+
+const post = {
+  bids: [[100, 2]],
+  asks: [[101, 0.5]]
+};
+
+const trade = { side: 'A', sz: 0.6, px: 101 };
+
+analyzer.process(trade, pre, post);
+console.log('Rolling bias:', analyzer.getBias().toFixed(2));

--- a/absorb/rollingBias.js
+++ b/absorb/rollingBias.js
@@ -1,0 +1,34 @@
+export class RollingBias {
+  constructor(windowSize = 50) {
+    this.windowSize = Math.max(1, windowSize);
+    this.buf = [];
+  }
+
+  /**
+   * Push a flow event into the rolling window.
+   * @param {'absorption'|'exhaustion'} type
+   * @param {'buy'|'sell'} side
+   */
+  push(type, side) {
+    let val = 0;
+    if (type === 'absorption') {
+      val = side === 'buy' ? 1 : -1;
+    } else if (type === 'exhaustion') {
+      val = side === 'buy' ? 0.3 : -0.3;
+    } else {
+      return;
+    }
+    this.buf.push(val);
+    if (this.buf.length > this.windowSize) this.buf.shift();
+  }
+
+  /**
+   * Current rolling bias value (mean of window).
+   * @returns {number}
+   */
+  value() {
+    if (!this.buf.length) return 0;
+    const sum = this.buf.reduce((s, v) => s + v, 0);
+    return sum / this.buf.length;
+  }
+}

--- a/absorb/tapeFlow.js
+++ b/absorb/tapeFlow.js
@@ -1,0 +1,53 @@
+import { RollingBias } from './rollingBias.js';
+
+export function depthDiff(a, b) {
+  const map = arr => new Map(arr.map(([p, s]) => [+p, +s]));
+  const [aB, bB, aA, bA] = [map(a.bids), map(b.bids), map(a.asks), map(b.asks)];
+  let bidEaten = 0, askEaten = 0;
+  for (const [p, s] of aB) bidEaten += Math.max(0, s - (bB.get(p) || 0));
+  for (const [p, s] of aA) askEaten += Math.max(0, s - (bA.get(p) || 0));
+  return { bidEaten, askEaten };
+}
+
+export function classifyTrade(trade, preBook, postBook) {
+  const notional = Math.abs(+trade.sz) * +trade.px;
+  const { bidEaten, askEaten } = depthDiff(preBook, postBook);
+  const type = bidEaten + askEaten > 0 ? 'absorption' : 'exhaustion';
+  const SIDE_MAP = { A: 'buy', B: 'sell', S: 'sell' };
+  const side = SIDE_MAP[trade.side] || trade.side;
+
+  let visibleDepth = 0;
+  if (type === 'absorption') {
+    const sideArr = side === 'buy' ? preBook.asks : preBook.bids;
+    const lvl = sideArr.find(([px]) => +px === +trade.px);
+    if (lvl) visibleDepth = lvl[1] * +trade.px;
+  }
+  const iceberg = type === 'absorption' && notional > visibleDepth;
+
+  return {
+    ts: Date.now(),
+    type,
+    side,
+    notional,
+    price: +trade.px,
+    bidEaten,
+    askEaten,
+    iceberg,
+    visibleDepth
+  };
+}
+
+export class TapeFlowAnalyzer {
+  constructor(biasWindow = 50) {
+    this.bias = new RollingBias(biasWindow);
+  }
+  process(trade, preBook, postBook) {
+    const event = classifyTrade(trade, preBook, postBook);
+    this.bias.push(event.type, event.side);
+    console.log('[tape]', JSON.stringify(event));
+    return event;
+  }
+  getBias() {
+    return this.bias.value();
+  }
+}

--- a/test/tapeFlow.test.js
+++ b/test/tapeFlow.test.js
@@ -1,0 +1,31 @@
+import { classifyTrade, TapeFlowAnalyzer } from '../absorb/tapeFlow.js';
+
+const baseBook = {
+  bids: [[100, 2]],
+  asks: [[101, 1]]
+};
+
+const tradeBuy = { side: 'A', sz: 1, px: 101 };
+const tradeSell = { side: 'B', sz: 1, px: 100 };
+
+test('classifies absorption with iceberg flag', () => {
+  const post = { bids: [[100, 2]], asks: [[101, 0.5]] };
+  const event = classifyTrade(tradeBuy, baseBook, post);
+  expect(event.type).toBe('absorption');
+  expect(event.side).toBe('buy');
+  expect(event.iceberg).toBe(true);
+});
+
+test('classifies exhaustion', () => {
+  const post = { bids: [[100, 3]], asks: [[101, 1]] };
+  const event = classifyTrade(tradeSell, baseBook, post);
+  expect(event.type).toBe('exhaustion');
+  expect(event.side).toBe('sell');
+});
+
+test('updates rolling bias via analyzer', () => {
+  const post = { bids: [[100, 2]], asks: [[101, 0.5]] };
+  const analyzer = new TapeFlowAnalyzer(3);
+  analyzer.process(tradeBuy, baseBook, post);
+  expect(analyzer.getBias()).toBeCloseTo(1);
+});


### PR DESCRIPTION
## Summary
- create `absorb` folder with rolling bias and tape flow utilities
- add small demo and documentation
- include tests for tape flow classification and bias calculation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d6a392b08329aeb9841264a8af60